### PR TITLE
fix: certbot: add pre-hook and post-hook to handle apache2 service

### DIFF
--- a/templates/certbot/playbook.yml.j2
+++ b/templates/certbot/playbook.yml.j2
@@ -7,6 +7,7 @@
   vars:
     certbot_admin_email: "{{ reverse_proxy.email }}"
     certbot_create_if_missing: true
+    certbot_auto_renew_options: "--pre-hook 'systemctl stop apache2' --post-hook 'systemctl start apache2'"
     certbot_create_standalone_stop_services:
     - apache2
     certbot_certs:


### PR DESCRIPTION
# Pull Request

## Summary

When we run `certbot renew` while the port 80 is already in use, the renewal process fails.

## Issue type

- Bugfix Pull Request

## Component

- certbot

## Additional information

We need to add a pre-hook to stop the apache2 service before `certbot renew`
Also, we need to add a post-hook to start the apache2 service after `certbot renew`

```
